### PR TITLE
Shorten input names

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Deploys a Task Definition as a Service in AWS ECS
           desired-count: 1
 
           # If you provide a task definition template, it will get registered:
-          task-definition-template-path: templates/ecs/my-task-definition.json
+          definition-template: templates/ecs/my-task-definition.json
 
           # You can override the image used on any container - the most common
           # use case is to deploy an image built & pushed on a previous step:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deploys a Task Definition as a Service in AWS ECS
         with:
           cluster: my-cluster
           deploy-aws-ecs-service: my-service
-          service-template-path: templates/ecs/my-service.json
+          template: templates/ecs/my-service.json
 
           # You can optionally specify the desired task count:
           desired-count: 1

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Deploys a Task Definition as a Service in AWS ECS
       - name: Deploy AWS ECS Service
         uses: icalia-actions/deploy-aws-ecs-service@v0.0.1
         with:
+          name: my-service
           cluster: my-cluster
-          deploy-aws-ecs-service: my-service
           template: templates/ecs/my-service.json
 
           # You can optionally specify the desired task count:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Deploys a Task Definition as a Service in AWS ECS
         uses: icalia-actions/deploy-aws-ecs-service@v0.0.1
         with:
           cluster: my-cluster
-          service-name: my-service
+          deploy-aws-ecs-service: my-service
           service-template-path: templates/ecs/my-service.json
 
           # You can optionally specify the desired task count:

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cluster:
     description: The AWS ECS cluster where we should run the task
     required: false
-  service-name:
+  deploy-aws-ecs-service:
     description: The name of your service. Up to 255 letters (uppercase and lowercase), numbers, and hyphens are allowed.
     required: true
   desired-count:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   force-new-deployment:
     description: Forces a new service deployment
     required: false
-  task-definition-template-path:
+  definition-template:
     description: The path to the AWS ECS Task Definition template to use
     required: false
   container-images:

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   target-group-arn:
     description: The Target Group ARN for the service to associate
     required: false
-  service-template-path:
+  template:
     description: The path to the AWS ECS Service template to use
     required: false
   force-new-deployment:

--- a/action.yml
+++ b/action.yml
@@ -6,12 +6,12 @@ branding:
   color: red
 
 inputs:
+  name:
+    description: The name of your service. Up to 255 letters (uppercase and lowercase), numbers, and hyphens are allowed.
+    required: true
   cluster:
     description: The AWS ECS cluster where we should run the task
     required: false
-  deploy-aws-ecs-service:
-    description: The name of your service. Up to 255 letters (uppercase and lowercase), numbers, and hyphens are allowed.
-    required: true
   desired-count:
     description: The number of instantiations of the specified task definition to place and keep running on your cluster.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,7 @@ function run() {
         };
         const taskRegistrationInput = {
             family: name,
-            templatePath: core_1.getInput("task-definition-template-path"),
+            templatePath: core_1.getInput("definition-template"),
             containerImages: JSON.parse(core_1.getInput("container-images") || "null"),
             environmentVars: JSON.parse(core_1.getInput("environment-vars") || "null"),
         };

--- a/package.json
+++ b/package.json
@@ -39,18 +39,18 @@
     "@types/node": "^14.14.37",
     "@types/tmp": "^0.2.0",
     "@vercel/ncc": "^0.27.0",
-    "aws-sdk": "^2.875.0",
     "dotenv": "^8.2.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3",
-    "yaml": "^1.10.2"
-  },
-  "dependencies": {
-    "@icalialabs/register-aws-ecs-task-definition": "^0.0.11",
+    "yaml": "^1.10.2",
     "jest": "^26.6.3",
     "jest-runtime": "^26.6.3",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "typescript-formatter": "^7.2.2"
+  },
+  "dependencies": {
+    "@icalialabs/register-aws-ecs-task-definition": "^0.0.13",
+    "aws-sdk": "^2.875.0"
   }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,30 +5,30 @@ import {
   TaskRegistrationInput,
 } from "@icalialabs/register-aws-ecs-task-definition";
 
-async function run(): Promise<number> {
+export async function run(): Promise<number> {
   const cluster = getInput("cluster");
-  const serviceName = getInput("deploy-aws-ecs-service");
+  const name = getInput("name");
 
   let desiredCount = parseInt(getInput("desired-count"));
   if (isNaN(desiredCount)) desiredCount = 1;
 
   const serviceDeploymentInput = {
     cluster,
-    serviceName,
+    name,
     desiredCount,
     targetGroupArn: getInput("target-group-arn"),
-    templatePath: getInput("service-template-path"),
+    template: getInput("template"),
     forceNewDeployment: getInput("force-new-deployment") == "true",
   } as ServiceDeploymentInput;
 
   const taskRegistrationInput = {
-    family: serviceName,
+    family: name,
     templatePath: getInput("task-definition-template-path"),
     containerImages: JSON.parse(getInput("container-images") || "null"),
     environmentVars: JSON.parse(getInput("environment-vars") || "null"),
   } as TaskRegistrationInput;
 
-  info(`Registering task definition '${serviceName}'...`);
+  info(`Registering task definition '${name}'...`);
   const { taskDefinitionArn } = await registerTaskDefinition(
     taskRegistrationInput
   );
@@ -36,19 +36,19 @@ async function run(): Promise<number> {
 
   serviceDeploymentInput.taskDefinition = taskDefinitionArn;
 
-  info(`Deploying service '${serviceName}'...`);
+  info(`Deploying service '${name}'...`);
   const deployedService = await deployService(serviceDeploymentInput);
   const { serviceArn, clusterArn } = deployedService;
   const region = process.env.AWS_DEFAULT_REGION;
 
   info("Service Update Details:");
-  info(`         Service Name: ${serviceName}`);
+  info(`         Service Name: ${name}`);
   info(`          Cluster ARN: ${clusterArn}`);
   info(`          Service ARN: ${serviceArn}`);
   info(`  Task Definition ARN: ${taskDefinitionArn}`);
   info("");
   info(
-    `Follow deployment progress at https://console.aws.amazon.com/ecs/v2/clusters/${cluster}/services/${serviceName}/deployments?region=${region}`
+    `Follow deployment progress at https://console.aws.amazon.com/ecs/v2/clusters/${cluster}/services/${name}/deployments?region=${region}`
   );
   info("");
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -23,7 +23,7 @@ export async function run(): Promise<number> {
 
   const taskRegistrationInput = {
     family: name,
-    templatePath: getInput("task-definition-template-path"),
+    templatePath: getInput("definition-template"),
     containerImages: JSON.parse(getInput("container-images") || "null"),
     environmentVars: JSON.parse(getInput("environment-vars") || "null"),
   } as TaskRegistrationInput;

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,7 +7,7 @@ import {
 
 async function run(): Promise<number> {
   const cluster = getInput("cluster");
-  const serviceName = getInput("service-name");
+  const serviceName = getInput("deploy-aws-ecs-service");
 
   let desiredCount = parseInt(getInput("desired-count"));
   if (isNaN(desiredCount)) desiredCount = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,10 +330,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@icalialabs/register-aws-ecs-task-definition@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@icalialabs/register-aws-ecs-task-definition/-/register-aws-ecs-task-definition-0.0.11.tgz#a79e802a3bf2b343024a53bc0e8a09cd20658e28"
-  integrity sha512-cqPHrvo608zQSww9A7BNcI0qnASxPAeyykrDYAd05xsPDEuKhVCJHXWtLGXuLFdIm3kqoV6ySMkQtYHU7m4BHA==
+"@icalialabs/register-aws-ecs-task-definition@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@icalialabs/register-aws-ecs-task-definition/-/register-aws-ecs-task-definition-0.0.13.tgz#2af926070f384a5c76e7b6392884eaff124599bd"
+  integrity sha512-sWcfWdsTC4fVk5nWl/UA2Pc8Kv054GcSQYynvBVROpXTt8l/oaBJ5uhtWVumPVepzHS0eFM9M86VtWbrGEQu1w==
   dependencies:
     aws-sdk "^2.875.0"
 


### PR DESCRIPTION
Shortens the name of some input arguments:
- `service-name` to just `name`
- `service-template-path` to just `template`
- `task-definition-template-path` to `definition-template`

Also updates npm package `@icalialabs/register-aws-ecs-task-definition` to version 0.0.13