### PR TITLE
Allow specifying load balancers instead of a target group

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ Deploys a Task Definition as a Service in AWS ECS
           # *must* be present in the definition, otherwise it will be ignored.
           secrets: '{"MY_SECRET":"some-secret-name"}'
 
-          # If your service must be associated with a load balancer target group,
-          # you can specify a Target Group ARN:
-          target-group-arn: my-target-group-arn
+          # If your service must be associated with any number of load
+          # balancers, you can specify those using a JSON array:
+          load-balancers: |-
+            [
+              {
+                "targetGroupArn":"my-target-group-arn",
+                "containerName":"my-container-name",
+                "containerPort":3000
+              },
+              {
+                "loadBalancerName":"my-classic-load-balancer",
+                "containerName":"my-container-name",
+                "containerPort":3000
+              }
+            ]
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,8 @@ inputs:
   desired-count:
     description: The number of instantiations of the specified task definition to place and keep running on your cluster.
     required: false
-  target-group-arn:
-    description: The Target Group ARN for the service to associate
+  load-balancers:
+    description: A JSON array of objects containing "targetGroupArn", "containerName" and "containerPort" (see https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/create-service.html)
     required: false
   template:
     description: The path to the AWS ECS Service template to use

--- a/dist/index.js
+++ b/dist/index.js
@@ -157,7 +157,6 @@ function processServiceDeployInput(input) {
         serviceToDeploy.taskDefinition = taskDefinition;
     if (loadBalancers)
         serviceToDeploy.loadBalancers = loadBalancers;
-    console.log("serviceToDeploy", serviceToDeploy);
     return serviceToDeploy;
 }
 function processServiceCreateInput(input) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -29,11 +29,11 @@ export async function run(): Promise<number> {
     desiredCount,
     template: getInput("template"),
     taskDefinition: taskDefinitionArn,
-    targetGroupArn: getInput("target-group-arn"),
+    loadBalancers: JSON.parse(getInput("load-balancers") || "null"),
     forceNewDeployment: getInput("force-new-deployment") == "true",
   } as ServiceDeploymentInput);
   const { serviceArn, clusterArn } = deployedService;
-  const region = process.env.AWS_DEFAULT_REGION;
+  const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
 
   info("Service Update Details:");
   info(`         Service Name: ${name}`);


### PR DESCRIPTION
Originally this action only allowed specifying one target group... which beats me (was I under a lot of pressure back then?)

Somehow that worked back then, but now it doesn't.

This PR changes the usage so several load balancers can be correctly specified instead.