### PR TITLE
Fix service deploy on inactive services

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -228,8 +228,10 @@ function createService(input) {
 function deployService(input) {
     return __awaiter(this, void 0, void 0, function* () {
         const serviceToDeploy = yield findService(input);
-        const deployMethod = serviceToDeploy ? updateService : createService;
-        return yield deployMethod(input);
+        if (!serviceToDeploy || serviceToDeploy.status == "INACTIVE") {
+            return createService(input);
+        }
+        return updateService(input);
     });
 }
 exports.deployService = deployService;

--- a/src/service-deployment.ts
+++ b/src/service-deployment.ts
@@ -144,6 +144,10 @@ export async function deployService(
   input: ServiceDeploymentInput
 ): Promise<Service> {
   const serviceToDeploy = await findService(input);
-  const deployMethod = serviceToDeploy ? updateService : createService;
-  return await deployMethod(input);
+
+  if (!serviceToDeploy || serviceToDeploy.status == "INACTIVE") {
+    return createService(input);
+  }
+
+  return updateService(input);
 }


### PR DESCRIPTION
The action failed on recently deleted services.

This fix won't work on services that are currently draining, but will work for services that finished draining.